### PR TITLE
perf: add new flag 动态密码

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4627,9 +4627,9 @@ dependencies = [
 
 [[package]]
 name = "tao"
-version = "0.22.2"
+version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f76221bce9db3af6b2b9cca4e92d8ea46c4cc88d785bc4b1a5cbcaab06f0b56"
+checksum = "f5d30690a6746dfbb26d4f41522757da1ebfd277514b58e27a80b7e55e511e52"
 dependencies = [
  "bitflags 1.3.2",
  "cairo-rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ description = "Automatic extraction of Email and SMS verification code for Mac p
 [dependencies]
 sys-locale = "0.3.1"
 tray-icon = "0.9.0"
-tao = "0.23.0"
+tao = "0.22.3"
 rust-i18n = "2.2.1"
 serde_json = "1.0.107"
 serde = "1.0.188"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,6 +66,7 @@ pub struct MAConfig {
 fn default_flags() -> Vec<String> {
     vec![
         "验证码".to_string(),
+        "动态密码".to_string(),
         "verification".to_string(),
         "code".to_string(),
         "인증".to_string(),

--- a/tests/lib_tests.rs
+++ b/tests/lib_tests.rs
@@ -27,6 +27,7 @@ fn test_check_captcha_or_other() {
     let stdout = "【自如网】自如验证码 356407，有效时间为一分钟，请勿将验证码告知任何人！如非您本人操作，请及时致电4001001111".to_string();
     let flags = vec![
         "验证码".to_string(),
+        "动态密码".to_string(),
         "verification".to_string(),
         "code".to_string(),
         "인증".to_string(),
@@ -83,6 +84,10 @@ fn test_get_captchas() {
     let stdout = "您的验证码是12345，请勿泄露给他人。".to_string();
     let captchas = get_captchas(&stdout);
     assert_eq!(captchas, vec!["12345".to_string()]);
+
+    let stdout = "您正在使用境外网上支付验证服务，动态密码为729729。动态密码连续输错3次，您的此次交易验证会失败。请勿向他人泄露！[中国工商银行]。【工商银行】".to_string();
+    let captchas = get_captchas(&stdout);
+    assert_eq!(captchas, vec!["729729".to_string()]);
 }
 
 #[test]


### PR DESCRIPTION
处理 [中国工商银行] 的境外支付验证码

> 您正在使用境外网上支付验证服务，动态密码为729729。动态密码连续输错3次，您的此次交易验证会失败。请勿向他人泄露！[中国工商银行]。【工商银行】